### PR TITLE
Build against RN 0.64.0 on JitPack

### DIFF
--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -50,7 +50,7 @@ repositories {
 dependencies {
   if (project == rootProject) {
     // If this is the root project (e.g. Jitpack), specify a version
-    implementation 'com.facebook.react:react-native:0.60.0-rc.1'
+    implementation 'com.facebook.react:react-native:0.64.0'
   } else {
     //noinspection GradleDynamicVersion
     api "com.facebook.react:react-native:+"

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -38,7 +38,7 @@ repositories {
   mavenCentral()
   if (project == rootProject) {
     maven {
-      url "https://dl.bintray.com/wordpress-mobile/react-native-mirror/"
+      url "https://a8c-libs.s3.amazonaws.com/android/react-native-mirror"
     }
   } else {
     // When building as a dep, the RN's maven repo is locally in the node_modules folder


### PR DESCRIPTION
This PR adds these changes to the "running" feat/jitpack branch:

1. Replace Bintray with the maven repo matintained for wordpress-mobile to find the react-native binary
2. Build against React Native 0.64.0 to accompany our effort to upgrade gutenberg-mobile to RN 0.64.0
